### PR TITLE
New commands introduced in Siunitx v3

### DIFF
--- a/siunitx.cwl
+++ b/siunitx.cwl
@@ -15,12 +15,23 @@
 \SI[options]{value}{unit commands}
 \SI{value}[pre-unit]{unit commands}
 \SI[options]{value}[pre-unit]{unit commands}
+\qty{value}{unit commands}
+\qty[options]{value}{unit commands}
 
 \numlist[options]{numbers}
 \numrange[options]{numbers}{number2}
+\numproduct[options]{numbers}
 
 \SIlist[options]{numbers}{unit}
 \SIrange[options]{number1}{number2}{unit}
+
+\qtylist[options]{numbers}{unit}
+\qtyrange[options]{number1}{number2}{unit}
+\qtyproduct[options]{numbers}{unit}
+
+\complexqty[options]{number}{unit}
+\complexnum{number}
+\complexnum[option]{number}
 
 \tablenum[options]{number}
 
@@ -37,6 +48,9 @@
 # Units with no values
 \si{unit}
 \si[options]{unit}
+
+\unit{unit}
+\unit[options]{unit}
 
 #
 # pre-defined units, prefixes and powers


### PR DESCRIPTION
The author did a larger rewrite of the siunitx package for v3 and also introduced new commands.
For example: `\qty{}{}` is the replacement for the (still working) `\SI{}{}`, and `\unit{}` for `\si{}`.

See also: https://mirror.informatik.hs-fulda.de/tex-archive/macros/latex/contrib/siunitx/siunitx.pdf#section.0.5 about the changes between v2 and v3